### PR TITLE
docs: update URL in js example

### DIFF
--- a/examples/javascript/blob_upload_download_webapi.html
+++ b/examples/javascript/blob_upload_download_webapi.html
@@ -192,7 +192,7 @@
                 <hgroup >
                     <h2>Blob Upload</h2>
                     <p>Upload blobs to Walrus, and display them on this page. See the
-                    <a href="https://fuzzy-bassoon-z4kp67p.pages.github.io/"target="_blank">
+                    <a href="https://mystenlabs.github.io/walrus-docs"target="_blank">
                     Walrus documentation</a> for more information.</p>
                 </hgroup>
 


### PR DESCRIPTION
Changed the docs URL to be the public URL.