### PR TITLE
chore: add mdbook to pre-commit hooks if installed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,17 @@ repos:
   hooks:
   - id: markdownlint-cli2
     args: ["--fix"]
+    pass_filenames: false
 - repo: https://github.com/crate-ci/typos
   rev: v1.22.0
   hooks:
   - id: typos
+    pass_filenames: false
+- repo: local
+  hooks:
+  - id: mdBook
+    name: Build mdBook if it is installed
+    language: system
+    entry: (which mdbook && mdbook build) || ! (which mdbook >> /dev/null)
+    files: 'docs/.*'
     pass_filenames: false


### PR DESCRIPTION
This check ensures that the documentation can be built successfully if `mdbook` is installed. If `mdbook-linkcheck` is installed as well, it also checks that all links in the docs are valid.