### PR TITLE
ci: add repository dispatch trigger for the update binaries workflow

### DIFF
--- a/.github/workflows/update-binaries.yaml
+++ b/.github/workflows/update-binaries.yaml
@@ -3,8 +3,6 @@ name: Update bin.walrus.site with latest binaries
 on:
   repository_dispatch:
     types: [update-sites-bins]
-
-on:
   # every week
   schedule:
     - cron: '14 3 * * 0'

--- a/.github/workflows/update-binaries.yaml
+++ b/.github/workflows/update-binaries.yaml
@@ -1,6 +1,10 @@
 name: Update bin.walrus.site with latest binaries
 
 on:
+  repository_dispatch:
+    types: [update-sites-bins]
+
+on:
   # every week
   schedule:
     - cron: '14 3 * * 0'


### PR DESCRIPTION
Adding repository dispatch to the Update Binaries workflow.