### PR TITLE
ci: more robust linkcheck

### DIFF
--- a/.github/actions/build-mdbook/action.yaml
+++ b/.github/actions/build-mdbook/action.yaml
@@ -1,6 +1,11 @@
 name: Build the mdBook
 description: Generate static site from markdown files through mdBook
 
+inputs:
+  with_linkcheck:
+    description: Check for broken links
+    default: "true"
+
 runs:
   using: "composite"
   steps:
@@ -15,6 +20,7 @@ runs:
         curl -sSL "$url" | tar -xz --directory=bin
       shell: bash
     - name: Install mdbook-linkcheck
+      if: ${{ inputs.with_linkcheck == 'true' }}
       run: |
         url="https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/latest/download/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip"
         curl -sSL "$url" -o mdbook-linkcheck.zip

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-mdbook
+        with:
+          with_linkcheck: "false"
       - uses: ./.github/actions/set-up-walrus
         with:
           SUI_ADDRESS: "${{ vars.SUI_ADDRESS }}"


### PR DESCRIPTION
This avoids failures to publish the page when the linkcheck fails. The linkcheck is still performed for PRs but not when building the page for publishing on the `main` branch.