### PR TITLE
docs: initial space for operator docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable headings no-empty-links -->
+
 # Summary
 
 [Walrus](./README.md)
@@ -31,6 +32,9 @@
   - [Components](./dev-guide/components.md)
   - [Operations](./dev-guide/dev-operations.md)
   - [Sui structures](./dev-guide/sui-struct.md)
+- [Operator Guide](./operator-guide/operator-guide.md)
+  - [Storage Node](./operator-guide/storage-node.md)
+  - [Aggregator](./operator-guide/aggregator.md)
 - [Setup](./usage/setup.md)
 - [Interacting with Walrus](./usage/interacting.md)
   - [Using the client CLI](./usage/client-cli.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,12 +28,12 @@
 
 # Usage
 
-- [Developer Guide](./dev-guide/dev-guide.md)
+- [Developer guide](./dev-guide/dev-guide.md)
   - [Components](./dev-guide/components.md)
   - [Operations](./dev-guide/dev-operations.md)
   - [Sui structures](./dev-guide/sui-struct.md)
-- [Operator Guide](./operator-guide/operator-guide.md)
-  - [Storage Node](./operator-guide/storage-node.md)
+- [Operator guide](./operator-guide/operator-guide.md)
+  - [Storage node](./operator-guide/storage-node.md)
   - [Aggregator](./operator-guide/aggregator.md)
 - [Setup](./usage/setup.md)
 - [Interacting with Walrus](./usage/interacting.md)

--- a/docs/dev-guide/dev-guide.md
+++ b/docs/dev-guide/dev-guide.md
@@ -1,4 +1,4 @@
-# Developer Guide
+# Developer guide
 
 This guide introduces all the concepts needed to build applications that use Walrus as a storage
 or availability layer. The [overview](../design/overview.md) provides more background and explains

--- a/docs/operator-guide/aggregator.md
+++ b/docs/operator-guide/aggregator.md
@@ -1,0 +1,22 @@
+# Aggregator node
+
+Below is an example of an Aggregator node which hosts a HTTP endpoint that can be used to fetch data from Walrus over the web.
+
+The aggregator process is run via the [Walrus CLI](../usage/client-cli.md). It can be run in many ways,
+one example being via a systemd service.
+
+```
+[Unit]
+Description=Walrus Aggregator Node
+
+[Service]
+User=walrus
+Environment=RUST_BACKTRACE=1
+Environment=RUST_LOG=info,walrus=debug
+ExecStart=/opt/walrus/bin/walrus --config /opt/walrus/config/client_config.yaml aggregator --bind-address 0.0.0.0:9000
+Restart=always
+
+LimitNOFILE=65536
+```
+
+More documentation on running a web api version of the aggregator can be found in the [usage guide](../usage/web-api.md).

--- a/docs/operator-guide/aggregator.md
+++ b/docs/operator-guide/aggregator.md
@@ -1,11 +1,12 @@
 # Aggregator node
 
-Below is an example of an Aggregator node which hosts a HTTP endpoint that can be used to fetch data from Walrus over the web.
+Below is an example of an Aggregator node which hosts a HTTP endpoint that can be used
+to fetch data from Walrus over the web.
 
-The aggregator process is run via the [Walrus CLI](../usage/client-cli.md). It can be run in many ways,
-one example being via a systemd service.
+The aggregator process is run via the [Walrus CLI](../usage/client-cli.md). It can be run in
+many ways, one example being via a systemd service.
 
-```
+```sh
 [Unit]
 Description=Walrus Aggregator Node
 
@@ -19,4 +20,5 @@ Restart=always
 LimitNOFILE=65536
 ```
 
-More documentation on running a web api version of the aggregator can be found in the [usage guide](../usage/web-api.md).
+More documentation on running a web api version of the aggregator can be found in the
+[usage guide](../usage/web-api.md).

--- a/docs/operator-guide/aggregator.md
+++ b/docs/operator-guide/aggregator.md
@@ -1,14 +1,14 @@
-# Aggregator node
+# Operating an aggregator
 
-Below is an example of an Aggregator node which hosts a HTTP endpoint that can be used
+Below is an example of an aggregator node which hosts a HTTP endpoint that can be used
 to fetch data from Walrus over the web.
 
-The aggregator process is run via the [Walrus CLI](../usage/client-cli.md). It can be run in
-many ways, one example being via a systemd service.
+The aggregator process is run via the `walrus` client binary in [daemon mode](../usage/web-api.md).
+It can be run in many ways, one example being via a systemd service:
 
-```sh
+```ini
 [Unit]
-Description=Walrus Aggregator Node
+Description=Walrus Aggregator
 
 [Service]
 User=walrus
@@ -19,6 +19,3 @@ Restart=always
 
 LimitNOFILE=65536
 ```
-
-More documentation on running a web api version of the aggregator can be found in the
-[usage guide](../usage/web-api.md).

--- a/docs/operator-guide/operator-guide.md
+++ b/docs/operator-guide/operator-guide.md
@@ -1,9 +1,10 @@
 # Operator Guide
 
-This guide introduces all the concepts needed for operators of the different components that make up the Walrus system.
-It is currently a work in progress and will be updated as the platform grows.
+This guide introduces all the concepts needed for operators of the different components that make
+up the Walrus system. It is currently a work in progress and will be updated as the platform grows.
 
 This guide describes the following:
 
-- [Storage node](storage-node.md), this describes the most relevant to operators of the Walrus node software.
+- [Storage node](storage-node.md), this describes the most relevant to operators of the Walrus node
+  software.
 - [Aggregator](aggregator.md), describes the operation of a Walrus Aggregator host.

--- a/docs/operator-guide/operator-guide.md
+++ b/docs/operator-guide/operator-guide.md
@@ -1,0 +1,9 @@
+# Operator Guide
+
+This guide introduces all the concepts needed for operators of the different components that make up the Walrus system.
+It is currently a work in progress and will be updated as the platform grows.
+
+This guide describes the following:
+
+- [Storage node](storage-node.md), this describes the most relevant to operators of the Walrus node software.
+- [Aggregator](aggregator.md), describes the operation of a Walrus Aggregator host.

--- a/docs/operator-guide/operator-guide.md
+++ b/docs/operator-guide/operator-guide.md
@@ -1,10 +1,10 @@
-# Operator Guide
+# Operator guide
 
-This guide introduces all the concepts needed for operators of the different components that make
+This chapter introduces all the concepts needed for operators of the different components that make
 up the Walrus system. It is currently a work in progress and will be updated as the platform grows.
 
-This guide describes the following:
+Specifically, this guide describes the following:
 
-- [Storage node](storage-node.md), this describes the most relevant to operators of the Walrus node
-  software.
-- [Aggregator](aggregator.md), describes the operation of a Walrus Aggregator host.
+- [Storage node](storage-node.md) contains the most relevant instructions for operators of a Walrus
+  storage node.
+- [Aggregator](aggregator.md) describes the operation of a Walrus aggregator host.

--- a/docs/operator-guide/storage-node.md
+++ b/docs/operator-guide/storage-node.md
@@ -1,11 +1,11 @@
 # Walrus Storage Node
 
-The binary of the storage node is not yet publicly available. It will be made available in September to
-operators for Testnet nodes. Prior to offical network launch the code will be open-sourced.
+The binary of the storage node is not yet publicly available. It will be made available in September
+to operators for Testnet nodes. Prior to official network launch the code will be open-sourced.
 
 A basic systemd service running the Storage Node could look like this:
 
-```
+```sh
 [Unit]
 Description=Walrus Storage Node
 
@@ -19,11 +19,12 @@ Restart=always
 LimitNOFILE=65536
 ```
 
-The `walrus-node` binary stores slivers in RocksDB, which means the data will be stored on disk, to a path configured by the `/opt/walrus/config/walrus-node.yaml` file.
+The `walrus-node` binary stores slivers in RocksDB, which means the data will be stored on disk, to
+a path configured by the `/opt/walrus/config/walrus-node.yaml` file.
 
 Here are some important config params from a shortened version of the `walrus-node.yaml` config file
 
-```
+```yaml
 storage_path: /opt/walrus/db
 metrics_address: 127.0.0.1:9184
 rest_api_address: 0.0.0.0:9185
@@ -40,4 +41,5 @@ blob_recovery:
   invalidity_sync_timeout_secs: 300
 ```
 
-For monitoring, you can configure Grafana Agent to fetch metrics from `localhost:9184/metrics` (or whatever you've configured `metrics_address` to be).
+For monitoring, you can configure Grafana Agent to fetch metrics from `localhost:9184/metrics`
+(or whatever you've configured `metrics_address` to be).

--- a/docs/operator-guide/storage-node.md
+++ b/docs/operator-guide/storage-node.md
@@ -1,0 +1,43 @@
+# Walrus Storage Node
+
+The binary of the storage node is not yet publicly available. It will be made available in September to
+operators for Testnet nodes. Prior to offical network launch the code will be open-sourced.
+
+A basic systemd service running the Storage Node could look like this:
+
+```
+[Unit]
+Description=Walrus Storage Node
+
+[Service]
+User=walrus
+Environment=RUST_BACKTRACE=1
+Environment=RUST_LOG=info,walrus=debug
+ExecStart=/opt/walrus/bin/walrus-node run --config-path /opt/walrus/config/walrus-node.yaml
+Restart=always
+
+LimitNOFILE=65536
+```
+
+The `walrus-node` binary stores slivers in RocksDB, which means the data will be stored on disk, to a path configured by the `/opt/walrus/config/walrus-node.yaml` file.
+
+Here are some important config params from a shortened version of the `walrus-node.yaml` config file
+
+```
+storage_path: /opt/walrus/db
+metrics_address: 127.0.0.1:9184
+rest_api_address: 0.0.0.0:9185
+sui:
+  rpc: https://fullnode.testnet.sui.io:443
+  system_object: 0xWALRUS_CONTRACT
+blob_recovery:
+  max_concurrent_blob_syncs: 10
+  retry_interval_min_secs: 1
+  retry_interval_max_secs: 3600
+  metadata_request_timeout_secs: 5
+  max_concurrent_metadata_requests: 1
+  sliver_request_timeout_secs: 300
+  invalidity_sync_timeout_secs: 300
+```
+
+For monitoring, you can configure Grafana Agent to fetch metrics from `localhost:9184/metrics` (or whatever you've configured `metrics_address` to be).

--- a/docs/operator-guide/storage-node.md
+++ b/docs/operator-guide/storage-node.md
@@ -1,11 +1,11 @@
-# Walrus Storage Node
+# Operating a storage node
 
 The binary of the storage node is not yet publicly available. It will be made available in September
 to operators for Testnet nodes. Prior to official network launch the code will be open-sourced.
 
 A basic systemd service running the Storage Node could look like this:
 
-```sh
+```ini
 [Unit]
 Description=Walrus Storage Node
 
@@ -19,10 +19,14 @@ Restart=always
 LimitNOFILE=65536
 ```
 
-The `walrus-node` binary stores slivers in RocksDB, which means the data will be stored on disk, to
-a path configured by the `/opt/walrus/config/walrus-node.yaml` file.
+Make sure to adjust any paths and, if desired, the log level.
 
-Here are some important config params from a shortened version of the `walrus-node.yaml` config file
+The `walrus-node` binary stores slivers in RocksDB, which means the data will be stored on disk, to
+a path configured by the `/opt/walrus/config/walrus-node.yaml` file. The full format with all
+mandatory and optional configuration parameters will be made available with the binary.
+
+Here are some important config params from a shortened version of the `walrus-node.yaml` config
+file:
 
 ```yaml
 storage_path: /opt/walrus/db


### PR DESCRIPTION
Adding a `Operator Guide` to the walrus docs. Pretty light on details for now, but it can be built out as we get closer to testnet + working with operators.

Some TODOs:

* Deployment + upgrade guide
* disk and machine spec
* Cache and publisher operator guides