### PR TITLE
fix: link for documentation is incorrect

### DIFF
--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -2,7 +2,8 @@
 
 ## Prerequisites
 
-- Set up Sui and Walrus as described in the [documentation](https://docs.walrus.site/usage/setup.html).
+- Set up Sui and Walrus as described in the 
+  [documentation](https://docs.walrus.site/usage/setup.html).
 - If you don't want to use the public aggregator and publisher: Run the client in [daemon
   mode](https://docs.walrus.site/usage/web-api).
 

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Set up Sui and Walrus as described in the [documentation](https://docs.walrus.site/usage/setup).
+- Set up Sui and Walrus as described in the [documentation](https://docs.walrus.site/usage/setup.html).
 - If you don't want to use the public aggregator and publisher: Run the client in [daemon
   mode](https://docs.walrus.site/usage/web-api).
 

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Set up Sui and Walrus as described in the 
+- Set up Sui and Walrus as described in the
   [documentation](https://docs.walrus.site/usage/setup.html).
 - If you don't want to use the public aggregator and publisher: Run the client in [daemon
   mode](https://docs.walrus.site/usage/web-api).


### PR DESCRIPTION
https://docs.walrus.site/usage/setup -> https://docs.walrus.site/usage/setup.html

right now says link is invalid 