### PR TITLE
chore: update the location of the site-builder config

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -68,5 +68,5 @@ jobs:
         run: >
           RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          --config walrus-sites/site-builder/assets/builder-example.yaml
+          --config walrus-sites/sites-config.yaml
           update build/html ${{ vars.WALRUS_SITE_OBJECT }}

--- a/.github/workflows/update-binaries.yaml
+++ b/.github/workflows/update-binaries.yaml
@@ -45,5 +45,5 @@ jobs:
         run: >
           RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          --config walrus-sites/site-builder/assets/builder-example.yaml
+          --config walrus-sites/sites-config.yaml
           update --list-directory site ${{ vars.WALRUS_SITE_BIN_OBJECT }}


### PR DESCRIPTION
Updates the location of the site builder config to match the `walrus-sites` repo.