### PR TITLE
chore: rust cache for walrus-sites

### DIFF
--- a/.github/actions/set-up-walrus/action.yaml
+++ b/.github/actions/set-up-walrus/action.yaml
@@ -68,6 +68,10 @@ runs:
     - name: Clone walrus-sites
       run: git clone https://github.com/MystenLabs/walrus-sites
       shell: bash
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: "walrus-sites -> target"
     - name: Build site-builder
       run: |
         cd walrus-sites


### PR DESCRIPTION
* use cache for rust to speed up building `sites-builder`

Contributes to #92 