### PR TITLE
chore: fix some typos in the project documentation and code 

### DIFF
--- a/docs/dev-guide/sui-struct.md
+++ b/docs/dev-guide/sui-struct.md
@@ -17,7 +17,7 @@ Walrus objects in your own Sui smart contracts.
 
 ```admonish danger title="A word of caution"
 Walrus Mainnet will use new Move packages with `struct` layouts and function signatures that may not
-be compatible with this package. Move code that builds against this package will need to rewritten.
+be compatible with this package. Move code that builds against this package will need to be rewritten.
 ```
 
 ## Blob and storage objects
@@ -114,7 +114,7 @@ public struct BlobCertified has copy, drop {
 ```
 
 The `BlobCertified` event with `deletable` set to false and an `end_epoch` in the future indicates
-that the blob will be available until this epoch. A light client proof this event was emitted
+that the blob will be available until this epoch. A light client proof that this event was emitted
 for a blob ID constitutes a proof of availability for the data with this blob ID.
 
 When a deletable blob is deleted, a `BlobDeleted` event is emitted:

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -1,6 +1,6 @@
 # The Walrus Sites portal
 
-We use the term "portal" to indicate any technology that is used to access a browse Walrus Sites.
+We use the term "portal" to indicate any technology that is used to access and browse Walrus Sites.
 As mentioned in the [overview](./overview.md#the-site-rendering-path), we foresee three kinds of
 portals:
 

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -1,6 +1,6 @@
 # The Walrus Sites portal
 
-We use the term "portal" to indicate any technology that is used to access an browse Walrus Sites.
+We use the term "portal" to indicate any technology that is used to access a browse Walrus Sites.
 As mentioned in the [overview](./overview.md#the-site-rendering-path), we foresee three kinds of
 portals:
 

--- a/docs/walrus-sites/routing.md
+++ b/docs/walrus-sites/routing.md
@@ -78,7 +78,7 @@ The **`routes` keys** are path patterns in the form `/path/to/some/*`, where the
 represents a wildcard.
 
 ```admonish
-Currently, the wildcard *can only be only be specified at the end of the path*.
+Currently, the wildcard *can only only be specified at the end of the path*.
 Therefore, `/path/*` is a valid path, while `/path/*/to` and `*/path/to/*` are not.
 ```
 

--- a/docs/walrus-sites/routing.md
+++ b/docs/walrus-sites/routing.md
@@ -78,7 +78,7 @@ The **`routes` keys** are path patterns in the form `/path/to/some/*`, where the
 represents a wildcard.
 
 ```admonish
-Currently, the wildcard *can only only be specified at the end of the path*.
+Currently, the wildcard *can only be specified at the end of the path*.
 Therefore, `/path/*` is a valid path, while `/path/*/to` and `*/path/to/*` are not.
 ```
 


### PR DESCRIPTION
### Pull Request Description
This PR fixes minor typos and improves clarity in documentation:

1. **`sui-struct.md`**: Fixed "need to rewritten" → "need to be rewritten".
                                       Fixed "proof this" → "proof that this"
2. **`portal.md`**: Corrected "an browse" → "a browse".
3. **`routing.md`**: Resolved "only be only be" → "only be".

These changes enhance readability and maintain consistency across the docs.
