### PR TITLE
ci: use pre-built site-builder binary

### DIFF
--- a/.github/actions/set-up-walrus/action.yaml
+++ b/.github/actions/set-up-walrus/action.yaml
@@ -65,17 +65,10 @@ runs:
         walrus info # Ensure the walrus binary works
       shell: bash
 
-    - name: Clone walrus-sites
-      run: git clone https://github.com/MystenLabs/walrus-sites
-      shell: bash
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: "walrus-sites -> target"
-    - name: Build site-builder
+    - name: Install and configure site-builder
       run: |
-        cd walrus-sites
-        cargo build --release
-        cp target/release/site-builder ../bin
-        cd -
+        curl https://storage.googleapis.com/mysten-walrus-binaries/site-builder-testnet-latest-ubuntu-x86_64 -o bin/site-builder
+        chmod +x bin/site-builder
+        curl -L https://github.com/MystenLabs/walrus-sites/raw/refs/heads/testnet/sites-config.yaml -o sites-config.yaml
+        site-builder --version
       shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,7 +69,6 @@ jobs:
         run: >
           RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          --config walrus-sites/sites-config.yaml
           update build/html ${{ vars.WALRUS_SITE_OBJECT }}
           --epochs 200
           --force

--- a/.github/workflows/update-binaries.yaml
+++ b/.github/workflows/update-binaries.yaml
@@ -45,7 +45,6 @@ jobs:
         run: >
           RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          --config walrus-sites/sites-config.yaml
           update --list-directory site ${{ vars.WALRUS_SITE_BIN_OBJECT }}
           --epochs 200
           --force


### PR DESCRIPTION
See https://github.com/MystenLabs/walrus-docs/actions/runs/12114599580/job/33771409749 for a workflow where the installation works. (The workflow fails for a different reason.)

Closes #92.

Closes WAL-413.