### PR TITLE
fix: temporarily remove Cookbook Onboard integration

### DIFF
--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -6,34 +6,3 @@
     amplitude.init('f60df2d0d709d50faa2ffda153a84bc0', { identityStorage:'none', defaultTracking: true });
   }
 </script>
-
-<script>
-    function initAskCookbook() {
-      // It's a public API key, so it's safe to expose it here
-      const PUBLIC_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NzU4Y2YyODM4NTcxODU5MjU0MGIyMDciLCJpYXQiOjE3MzM4NzM0NDgsImV4cCI6MjA0OTQ0OTQ0OH0.Z3cv3HuMkYq3aYZYzCKkkYuM5LI3KG-kuA0R-GaSMV4";
-
-      let cookbookContainer = document.getElementById("__cookbook");
-      if (!cookbookContainer) {
-        cookbookContainer = document.createElement("div");
-        cookbookContainer.id = "__cookbook";
-        cookbookContainer.dataset.apiKey = PUBLIC_API_KEY;
-        document.body.appendChild(cookbookContainer);
-      }
-
-      let cookbookScript = document.getElementById("__cookbook-script");
-      if (!cookbookScript) {
-        cookbookScript = document.createElement("script");
-        cookbookScript.id = "__cookbook-script";
-        cookbookScript.src = "https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js";
-        cookbookScript.async = true;
-        document.head.appendChild(cookbookScript);
-      }
-    }
-
-    // Check if the document is already loaded and if so, initialize the script, otherwise wait for the load event
-    if (document.readyState === "complete") {
-      initAskCookbook();
-    } else {
-      window.addEventListener("load", initAskCookbook);
-    }
-  </script>


### PR DESCRIPTION
Due to the bad interaction of the Cookbook integration and mdBook's keyboard shortcuts (see https://github.com/MystenLabs/walrus-docs/pull/184#issuecomment-2540798014), I'm removing the integration for now. This reverts commit 7fca07a0724a15a614d2fdc26c50ba2a4e42d062.