### PR TITLE
docs: update about portal hosting

### DIFF
--- a/docs/walrus-sites/linking.md
+++ b/docs/walrus-sites/linking.md
@@ -1,5 +1,13 @@
 # Linking from and to Walrus Sites
 
+``` admonish warning title="Walrus Sites links are currently unavailable"
+This feature is currently unavailable on server-side portals.
+So if you are browsing a Walrus Site on <https://walrus.site>,
+you will not be able to use Walrus Sites links.
+
+We are working on enabling this feature. Stay tuned!
+```
+
 Links in Walrus Sites work *almost* as you would expect in a regular website. We specify here a few
 of the details.
 

--- a/docs/walrus-sites/linking.md
+++ b/docs/walrus-sites/linking.md
@@ -1,9 +1,8 @@
 # Linking from and to Walrus Sites
 
 ``` admonish warning title="Walrus Sites links are currently unavailable"
-This feature is currently unavailable on server-side portals.
-So if you are browsing a Walrus Site on <https://walrus.site>,
-you will not be able to use Walrus Sites links.
+This feature is currently unavailable on server-side portals. So if you are browsing a Walrus Site
+on <https://walrus.site>, you will not be able to use Walrus Sites links.
 
 We are working on enabling this feature. Stay tuned!
 ```

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -17,6 +17,9 @@ and the server-portal at <https://blob.store>. This is no longer the case.
 The service-worker portal is no longer hosted, but you can run it locally
 because its' code is still available in the `walrus-sites` repository.
 For more information, see [running the portal locally](#running-the-portal-locally).
+
+The old domain, `blob.store` is currently an alias for `walrus.site`
+but will be removed in the future.
 ```
 
 ```admonish danger title="Walrus Sites stable branch"

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -14,8 +14,8 @@ Currently, only a server-side portal is served at <https://walrus.site>.
 In the past, the service-worker based portal was hosted at <https://walrus.site>
 and the server-portal at <https://blob.store>. This is no longer the case.
 
-The service-worker portal is no longer hosted, but you can run it locally
-because its' code is still available in the `walrus-sites` repository.
+The service-worker portal is no longer hosted, but you can still run it locally. 
+Its code is available in the `walrus-sites` repository.
 For more information, see [running the portal locally](#running-the-portal-locally).
 
 The old domain, `blob.store` is currently an alias for `walrus.site`

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -11,15 +11,15 @@ portals:
 Currently, only a server-side portal is served at <https://walrus.site>.
 
 ```admonish note title="Hosting of the service worker"
-In the past, the service-worker based portal was hosted at <https://walrus.site>
-and the server-portal at <https://blob.store>. This is no longer the case.
+In the past, the service-worker based portal was hosted at <https://walrus.site> and the
+server-portal at <https://blob.store>. This is no longer the case.
 
-The service-worker portal is no longer hosted, but you can still run it locally. 
-Its code is available in the `walrus-sites` repository.
-For more information, see [running the portal locally](#running-the-portal-locally).
+The service-worker portal is no longer hosted, but you can still run it locally. Its code is
+available in the `walrus-sites` repository. For more information, see
+[running the portal locally](#running-the-portal-locally).
 
-The old domain, `blob.store` is currently an alias for `walrus.site`
-but will be removed in the future.
+The old domain, `blob.store` is currently an alias for `walrus.site` but will be removed in the
+future.
 ```
 
 ```admonish danger title="Walrus Sites stable branch"

--- a/docs/walrus-sites/portal.md
+++ b/docs/walrus-sites/portal.md
@@ -8,8 +8,16 @@ portals:
 1. custom local apps; and
 1. service-worker based portals in the browser.
 
-Currently, the server-side and service-workers portals are available at <https://blob.store> and
-<https://walrus.site>, respectively.
+Currently, only a server-side portal is served at <https://walrus.site>.
+
+```admonish note title="Hosting of the service worker"
+In the past, the service-worker based portal was hosted at <https://walrus.site>
+and the server-portal at <https://blob.store>. This is no longer the case.
+
+The service-worker portal is no longer hosted, but you can run it locally
+because its' code is still available in the `walrus-sites` repository.
+For more information, see [running the portal locally](#running-the-portal-locally).
+```
 
 ```admonish danger title="Walrus Sites stable branch"
 The stable branch of Walrus Sites is `testnet`.
@@ -17,11 +25,11 @@ The stable branch of Walrus Sites is `testnet`.
 
 ## Running the portal locally
 
-You can run a service-worker portal locally if you want to browse Walrus Sites without accessing
+You can run a portal locally if you want to browse Walrus Sites without accessing
 external portals or for development purposes.
 
 This requires having the [`pnpm`](https://pnpm.io/) tool installed. To start, clone the
-`walrus-sites` repo and enter the `portal` directory. Here, run
+`walrus-sites` repo and enter the `portal` directory.
 
 Make sure you are on the stable branch:
 
@@ -33,8 +41,9 @@ git checkout testnet
 cd portal
 pnpm install
 # Build the portal you want to use, or both
-pnpm build:worker
 pnpm build:server
+pnpm build:worker
+
 ```
 
 to install the dependencies, and then either one of the following commands:
@@ -58,10 +67,10 @@ The most important configuration parameters for the portal are in `portal/common
 
 - `NETWORK`: The Sui network to be used for fetching the Walrus Sites objects. Currently, we
   use Sui `testnet`.
-- `AGGREGATOR`: The URL of the [aggregator](../usage/web-api.md) from which the service worker will
+- `AGGREGATOR`: The URL of the [aggregator](../usage/web-api.md) from which the portal will
   fetch the Walrus blobs.
 - `SITE_PACKAGE`: The Sui object ID of the Walrus Sites package.
-- `MAX_REDIRECT_DEPTH`: The number of [redirects](./redirects.md) the service worker will follow
+- `MAX_REDIRECT_DEPTH`: The number of [redirects](./redirects.md) the portal will follow
   before stopping.
 - `SITE_NAMES`: Hard coded `name: objectID` mappings, to override the SuiNS names. For development
   only.


### PR DESCRIPTION
- The server portal is now hosted on `walrus.site` 
- The service-worker portal is no longer being hosted, but its' code is still available for local hosting.