### PR TITLE
fix: incorrect `runs-on` environment and `with_linkcheck` parameter type in GitHub Actions workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
   # (https://github.com/MystenLabs/walrus-docs/settings/secrets/actions).
   publish-walrus:
     name: Update Walrus Site
-    runs-on: ubuntu-ghcloud
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || inputs.update-walrus-site == true }}
     env:
       # Colors don't seem to work properly with the multiline commands.
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-mdbook
         with:
-          with_linkcheck: "false"
+          with_linkcheck: false
       - uses: ./.github/actions/set-up-walrus
         with:
           SUI_ADDRESS: "${{ vars.SUI_ADDRESS }}"


### PR DESCRIPTION
- Changed `runs-on` from `ubuntu-ghcloud` to `ubuntu-latest` to use a valid GitHub Actions environment.
- Corrected the `with_linkcheck` parameter from a string (`"false"`) to a boolean (`false`) in the `publish-walrus` job.