### PR TITLE
chore: update the walrus sites docs to align with 

### DIFF
--- a/docs/walrus-sites/authentication.md
+++ b/docs/walrus-sites/authentication.md
@@ -32,7 +32,7 @@ has been fetched) did not tamper with the contents of the blob.
 
 Here, the portal provider is only trusted to provide the correct service worker code to the user.
 The user's browser will then perform the fetching and authentication. The guarantees are therefore
-the same as with the remote server-site portal, with the addition that the user can inspect the code
+the same as with the remote server-side portal, with the addition that the user can inspect the code
 returned by the portal provider and verify its integrity (e.g., by comparing it the hash of the
 service worker code to one that is known to be correct).
 

--- a/docs/walrus-sites/intro.md
+++ b/docs/walrus-sites/intro.md
@@ -33,8 +33,8 @@ You can check out the mint page at <https://flatland.walrus.site/>. This site is
 browser through the Walrus Site *portal* <https://walrus.site>. While the portal's operation is
 explained in a [later section](./portal.md), consider for now that there can be many portals (hosted
 by whoever wants to have their own, and even on `localhost`). Further, the only function of the
-portal is to provide the browser with some code (specifically, a service worker) that allows it to
-fetch the Walrus Site from Sui and Walrus.
+portal is to retrieve the metadata (from Sui) and the resource files (from Walrus) that constitute
+the site.
 
 If you have a Sui wallet with some Testnet SUI, you can try and "mint a new Flatlander" from the
 site. This creates an NFT from the collection and shows you two links: one to the explorer, and one

--- a/docs/walrus-sites/overview.md
+++ b/docs/walrus-sites/overview.md
@@ -100,9 +100,10 @@ Base36 was chosen for two reasons, forced by the subdomain standards:
 As mentioned before, we provide two types of portals to browse Walrus Sites:
 
 - The server-side portal, which is a server that resolves a Walrus Site, returning it to the
-  browser. The server-side portal is hosted at <https://blob.store>.
-- The service-worker portal, which is a service worker that is installed in the browser and resolves
-  a Walrus Site. The service-worker portal is hosted at <https://walrus.site>.
+  browser. The server-side portal is hosted at <https://walrus.site>.
+- The service-worker portal, which is a service worker that is installed in the browser and
+  resolves a Walrus Site. The service-worker portal is no longer hosted at a specific domain, but
+  the code is still maintained so that it can be used by anyone.
 
 We now describe the resolution process of a Walrus Site in the browser using the service-worker
 portal as an example.
@@ -134,6 +135,14 @@ worker approach. The steps below all reference the following figure:
 
 These steps are executed for all resources the browser may query thereafter (for example, if
 `/index.html` points to `assets/cat.png`).
+
+```admonish tip title="Server side approach"
+The server-side portal works similarly, but the resolution is performed by the server. Meaning that
+the server will resolve the SuiNS name, fetch the dynamic fields, and return the resources to the
+browser, without anything else happening on the user's side. So the steps 2-6 are no longer
+relevant, and 7-10 are performed by the server. The resulting resources are transmitted to the
+browser in a standard HTTP response.
+```
 
 ## The site builder
 

--- a/docs/walrus-sites/restrictions.md
+++ b/docs/walrus-sites/restrictions.md
@@ -46,8 +46,8 @@ result in a dysfunctional site and a poor experience for the user.
 ### iOS Sui mobile wallets do not work with the service-worker portal
 
 ```admonish warning
-This limitation **only applies to portal based on service workers**. If you need to support
-this feature, you should use a server-side portal.
+This limitation **only applies to portal based on service workers**. If you need to access sites
+that support this feature, you should use a server-side portal.
 ```
 
 Service workers cannot be loaded inside an in-app browser on iOS, because of a limitation of the
@@ -65,8 +65,8 @@ to the `<site_name>.walrus.site` server-side portal. This way, the user can stil
 ### Service worker portals do not support progressive web apps (PWAs)
 
 ```admonish warning
-This limitation **only applies to portal based on service workers**. If you need to support
-this feature, you should use a server-side portal.
+This limitation **only applies to portal based on service workers**. If you need to access sites
+that support this feature, you should use a server-side portal.
 ```
 
 With the current design, service-worker portals cannot be used to access progressive web apps

--- a/docs/walrus-sites/restrictions.md
+++ b/docs/walrus-sites/restrictions.md
@@ -22,9 +22,19 @@ does not result in an infinite loading loop.
 Different portals can set this limit as they desire. The limit for the portal hosted at
 <https://walrus.site> has a maximum redirect depth of 3.
 
-## Service workers are not available
+## Service-worker portal limitations
 
-Walrus Sites leverage service workers in the clients' browsers to perform essential operations:
+The following limitations apply to portals based on service workers:
+
+```admonish warning
+This limitation **only applies to portal based on service workers**. If you need to support
+this feature, you should use a server-side portal.
+```
+
+### Service-worker portals, can't serve sites based on service workers
+
+Service-worker portals leverage service workers in the clients' browsers to perform essential
+operations:
 
 1. reading the site metadata from Sui;
 1. fetching the page content from Walrus; and
@@ -34,31 +44,32 @@ Therefore, a site deployed on Walrus Sites cannot use service workers itself. In
 worker from within a Walrus Site will result in a dysfunctional site and a poor experience for the
 user.
 
-```admonish note
-This limitation only applies to portal based on service workers. A web portal will not
-have this limitation.
-```
+### iOS Sui mobile wallets do not work with the service-worker portal
 
-## iOS Sui mobile wallets do not work with the service-worker portal
+```admonish warning
+This limitation **only applies to portal based on service workers**. If you need to support
+this feature, you should use a server-side portal.
+```
 
 Service workers cannot be loaded inside an in-app browser on iOS, because of a limitation of the
 WebKit engine. As a consequence, Walrus Sites cannot be used within Sui-compatible wallet apps on
 iOS. Therefore, Sui wallets cannot currently be used on a service-worker portal on iOS. Note,
 however, that *browsing* a Walrus Site is still possible on iOS through any browser.
 
-To provide a seamless experience for iOS users (and other users on browsers that do not support
-service workers), we implemented a redirect to a server-side portal (<https://blob.store>). Whenever
-a user on an iOS wallet browses a Walrus Site, the redirect will automatically take them to the
-`<site_name>.blob.store` server-side portal. This way, the user can still use the wallet.
+Given that you decided to use a service-worker portal as your main point of access to your sites,
+to provide a seamless experience for iOS users (and other users on browsers that do not support
+service workers), it is recommended to redirect to a server-side portal (<https://walrus.site>).
+Whenever a user on an iOS wallet browses a Walrus Site, the redirect will automatically take them
+to the `<site_name>.walrus.site` server-side portal. This way, the user can still use the wallet.
 
-```admonish note
-This limitation only applies to portals based on service workers. A web portal will not
-have this limitation.
+### Service worker portals do not support progressive web apps (PWAs)
+
+```admonish warning
+This limitation **only applies to portal based on service workers**. If you need to support
+this feature, you should use a server-side portal.
 ```
 
-## No support for progressive web apps (PWAs)
-
-With the current design, Walrus Sites cannot be used for progressive web apps (PWAs).
+With the current design, service-worker portals cannot be used for progressive web apps (PWAs).
 
 Two characteristics of the service-worker portal prevent support for PWAs:
 

--- a/docs/walrus-sites/restrictions.md
+++ b/docs/walrus-sites/restrictions.md
@@ -24,11 +24,10 @@ Different portals can set this limit as they desire. The limit for the portal ho
 
 ## Service-worker portal limitations
 
-The following limitations apply to portals based on service workers:
+The following limitations only apply to portals based on service workers.
 
-```admonish warning
-This limitation **only applies to portal based on service workers**. If you need to support
-this feature, you should use a server-side portal.
+``` admonish tip
+If you need to support any of the features listed below, you should use a server-side portal.
 ```
 
 ### Service-worker portals, can't serve sites based on service workers
@@ -40,9 +39,9 @@ operations:
 1. fetching the page content from Walrus; and
 1. serving the content to the browser.
 
-Therefore, a site deployed on Walrus Sites cannot use service workers itself. Installing a service
-worker from within a Walrus Site will result in a dysfunctional site and a poor experience for the
-user.
+Therefore, a site accessed by a service-worker portal cannot use service workers itself. i.e.
+you can't "stack" service workers! Installing a service worker from within a Walrus Site will
+result in a dysfunctional site and a poor experience for the user.
 
 ### iOS Sui mobile wallets do not work with the service-worker portal
 
@@ -52,9 +51,10 @@ this feature, you should use a server-side portal.
 ```
 
 Service workers cannot be loaded inside an in-app browser on iOS, because of a limitation of the
-WebKit engine. As a consequence, Walrus Sites cannot be used within Sui-compatible wallet apps on
-iOS. Therefore, Sui wallets cannot currently be used on a service-worker portal on iOS. Note,
-however, that *browsing* a Walrus Site is still possible on iOS through any browser.
+WebKit engine. As a consequence, Walrus Sites that are accessed through a service worker portal
+cannot be used within Sui-compatible wallet apps on iOS. Therefore, Sui wallets cannot currently
+be used on a service-worker portal on iOS. Note, however, that *browsing* a Walrus Site is still
+possible on iOS through any browser.
 
 Given that you decided to use a service-worker portal as your main point of access to your sites,
 to provide a seamless experience for iOS users (and other users on browsers that do not support
@@ -69,7 +69,8 @@ This limitation **only applies to portal based on service workers**. If you need
 this feature, you should use a server-side portal.
 ```
 
-With the current design, service-worker portals cannot be used for progressive web apps (PWAs).
+With the current design, service-worker portals cannot be used to access progressive web apps
+(PWAs).
 
 Two characteristics of the service-worker portal prevent support for PWAs:
 

--- a/docs/walrus-sites/tutorial-publish.md
+++ b/docs/walrus-sites/tutorial-publish.md
@@ -9,12 +9,13 @@ The `site-builder` works by uploading a directory of files produced by any web f
 and adding the relevant metadata to Sui. This directory should have a file called `index.html` in
 its root, which will be the entry point to the Walrus Site.
 
-There is a very useful [example-Walrus-sites](https://github.com/MystenLabs/example-walrus-sites)
+There is a very useful [example-walrus-sites](https://github.com/MystenLabs/example-walrus-sites)
 repository that contains multiple kinds of sites that you can use for reference.
 
 For simplicity, we will start by publishing the most frugal of the sites, the `walrus-snake` game.
 
-First, clone the repository of examples:
+
+First, clone the repository of the examples:
 
 ``` sh
 git clone https://github.com/MystenLabs/example-walrus-sites.git && cd walrus-snake/

--- a/docs/walrus-sites/tutorial-publish.md
+++ b/docs/walrus-sites/tutorial-publish.md
@@ -9,11 +9,10 @@ The `site-builder` works by uploading a directory of files produced by any web f
 and adding the relevant metadata to Sui. This directory should have a file called `index.html` in
 its root, which will be the entry point to the Walrus Site.
 
-There is a very useful [example-walrus-sites](https://github.com/MystenLabs/example-walrus-sites)
+There is a very useful [example-Walrus-sites](https://github.com/MystenLabs/example-walrus-sites)
 repository that contains multiple kinds of sites that you can use for reference.
 
 For simplicity, we will start by publishing the most frugal of the sites, the `walrus-snake` game.
-
 
 First, clone the repository of the examples:
 


### PR DESCRIPTION
### Changelog
- Update `intro.md`: there was a mention to the service worker that we missed in the past. 
- Update the `restrictions.md`. 
- Fix typos.